### PR TITLE
Reorganize Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: all run build
+all: install
 
-all:
+.PHONY: install
+install:
 	bundle install
 
+.PHONY: run
 run:
 	bundle exec jekyll server --watch
 
+.PHONY: build
 build:
 	bundle exec jekyll build


### PR DESCRIPTION
This way of organizing the Makefile tries to be more explicit in what
part of the Makefile has dependencies, and what is phony.
